### PR TITLE
Change table and file name of Talks

### DIFF
--- a/migrations/20190126213457_assists.sql
+++ b/migrations/20190126213457_assists.sql
@@ -1,21 +1,21 @@
 -- +goose Up
 -- SQL in section 'Up' is executed when this migration is applied
 
-create table if not exists assistants (
+create table if not exists assists (
   id            uuid primary key default gen_random_uuid(),
   talk_id       uuid references talks(id),
-  speaker       uuid references users(id),
-  assistant     uuid references users(id),
+  speaker_id       uuid references users(id),
+  assistant_id     uuid references users(id),
 
 	created_at      timestamptz default now(),
 	updated_at      timestamptz default now(),
 	deleted_at      timestamptz
 );
 
-create trigger update_assistants_updated_at
-before update on assistants for each row execute procedure update_updated_at_column();
+create trigger update_assists_updated_at
+before update on assists for each row execute procedure update_updated_at_column();
 -- +goose Down
 -- SQL section 'Down' is executed when this migration is rolled back
-drop table if exists assistants cascade;
+drop table if exists assists cascade;
 
 


### PR DESCRIPTION
* In order to improve readability and consistency towards
service. The old name assistants and attends(file) are changed
to assists and assist(file). This because in that table we are creating
a relation between two user and a talk given by one of those two users.
This relation is an assitance to a talk from the other one user left.

* Also, change the column names speaker and assitant and add to them
a sufix to specify that they are an id